### PR TITLE
Add three seconds of delay to song play.

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,8 +24,8 @@ const Center = styled.div`
 `;
 
 const Header = () => {
-  const [, handlers] = useConfig();
-  const { setPath, nextPage, previousPage, songEnded } = handlers;
+  const [state, handlers] = useConfig();
+  const { setPath, nextPage, previousPage } = handlers;
 
   const handleChangeClick = () => {
     remote.dialog.showOpenDialog({ properties: ['openDirectory'] }, (paths) => {
@@ -45,7 +45,10 @@ const Header = () => {
   };
 
   const handleSkipClick = () => {
-    songEnded();
+    const { currentSong } = state;
+    if (currentSong) {
+      currentSong.howl.stop();
+    }
   }
 
   return (

--- a/src/components/Runtime.tsx
+++ b/src/components/Runtime.tsx
@@ -16,8 +16,17 @@ const Runtime = () => {
   }, [title]);
 
   useInterval((v) => {
-    setTime(time + 1)
-  }, currentSong ? 1000 : null);
+    if (!currentSong) {
+      return;
+    }
+
+    const seek = currentSong.howl.seek() || 0;
+
+    if (typeof seek === 'number') {
+      setTime(seek)
+    }
+
+  }, currentSong ? 100 : null);
 
   return (
     <>

--- a/src/parseLibraryFromPath.ts
+++ b/src/parseLibraryFromPath.ts
@@ -1,5 +1,4 @@
 import { sync as globSyng } from 'glob';
-import { Howl } from 'howler';
 import { parseFile } from 'music-metadata';
 
 async function parseLibraryFromPath(pathToLibrary: string) {
@@ -19,13 +18,6 @@ async function parseLibraryFromPath(pathToLibrary: string) {
       title,
       year,
       path: songPath,
-      player: () => new Howl({
-        autoplay: true,
-        html5: true,
-        preload: true,
-        src: `file:///${songPath}`,
-        // sprite: { intro: [0, 5000] },
-      }),
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export interface PlayableSong extends SongWithKey {
   year: number;
   path: string;
   duration: number;
-  player: () => Howl;
 }
 
 export type Tile = PlayableSong[];

--- a/src/useInterval.ts
+++ b/src/useInterval.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 export function useInterval(callback, delay) {
-  const savedCallback = useRef();
+  const savedCallback = useRef<any>();
 
   // Remember the latest callback.
   useEffect(() => {
@@ -11,7 +11,7 @@ export function useInterval(callback, delay) {
   // Set up the interval.
   useEffect(() => {
     function tick() {
-      (savedCallback as any).current();
+      savedCallback.current();
     }
     if (delay !== null) {
       let id = setInterval(tick, delay);
@@ -19,4 +19,33 @@ export function useInterval(callback, delay) {
     }
     return;
   }, [delay]);
+}
+
+export function useTimeout(callback, delay, ...props) {
+  const savedCallback = useRef<any>();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      return savedCallback.current();
+    }
+    if (delay !== null) {
+      let cleanup = () => {};
+      let id = setTimeout(() => {
+        cleanup = tick()
+      }, delay);
+      return () => {
+        if(cleanup){
+          cleanup();
+        }
+        clearInterval(id)
+      };
+    }
+    return;
+  }, [delay, ...props]);
 }


### PR DESCRIPTION
PO request to emulate delay of original jukebox.

- Instead of a Howler factory function on the PlayableSong type, we now have the actual Howl which is created when the song is moved into the currentSong position. This allows us to call stop on it directly (skip) and also allows us to call seek() to get our current time.
- Using useTimeout in the Player delays the song play by 3 seconds. Currently this includes the initial song added to the queue.