### PR TITLE
Add library caching

### DIFF
--- a/src/parseLibraryFromPath.ts
+++ b/src/parseLibraryFromPath.ts
@@ -1,27 +1,91 @@
-import { sync as globSyng } from 'glob';
-import { parseFile } from 'music-metadata';
-import { ExtendedSong } from './types';
+import { sync as globSync } from "glob";
+import { parseFile } from "music-metadata";
+import { ExtendedSong } from "./types";
+import { get, set } from "./storage";
 
-async function parseLibraryFromPath(pathToLibrary: string) {
-  const songPaths = globSyng(`${pathToLibrary}/**/*.{mp3,m4a}`);
+function stringifySongPaths(paths: string[]): string {
+  console.time(`stringifySongPaths`);
+  const result = paths.join(" ");
+  console.timeEnd(`stringifySongPaths`);
+  return result;
+}
 
-  const values: ExtendedSong[] = [];
-  for (const songPath of songPaths) {
+async function storeCacheKey(challenge: string) {
+  console.time(`set cache`);
+  const result = set("cache", challenge);
+  console.timeEnd(`set cache`);
+  return result;
+}
+
+async function getLibraryCache() {
+  console.time(`getLibraryCache:get`);
+  const result: string = await get("library");
+  console.timeEnd(`getLibraryCache:get`);
+
+  console.time(`getLibraryCache:parse`);
+  const obj = JSON.parse(result);
+  console.timeEnd(`getLibraryCache:parse`);
+  return obj;
+}
+
+function storeLibraryCache(values: ExtendedSong[]) {
+  console.time(`storeLibraryCache:stringify`);
+  const string = JSON.stringify(values);
+  console.timeEnd(`storeLibraryCache:stringify`);
+
+  console.time(`storeLibraryCache:set`);
+  const result = set("library", string);
+  console.timeEnd(`storeLibraryCache:set`);
+  return result;
+}
+
+async function buildExtendedSongsFromPath(
+  songPaths: string[],
+  values: ExtendedSong[] = []
+): Promise<ExtendedSong[]> {
+  console.time(`buildExtendedSongsFromPath`);
+  for (const path of songPaths) {
     const {
       common: { artist, title, year },
-      format: { duration },
-    } = await parseFile(songPath, { skipCovers: true });
-
+      format: { duration }
+    } = await parseFile(path, { skipCovers: true, skipPostHeaders: true });
     if (duration && artist && title && year) {
       values.push({
-        duration: duration,
+        duration,
         artist,
         title,
         year,
-        path: songPath,
+        path
       });
     }
   }
+  console.timeEnd(`buildExtendedSongsFromPath`);
+  return values;
+}
+
+function buildSongPaths(pathToLibrary: string): string[] {
+  console.time(`buildSongPaths`);
+  const result = globSync(`${pathToLibrary}/**/*.{mp3,m4a}`);
+  console.timeEnd(`buildSongPaths`);
+  return result;
+}
+
+async function parseLibraryFromPath(pathToLibrary: string) {
+  const songPaths = buildSongPaths(pathToLibrary);
+
+  const cacheKey: string = await get("cache");
+
+  const challenge = stringifySongPaths(songPaths);
+
+  if (cacheKey === challenge) {
+    return getLibraryCache();
+  }
+
+  await storeCacheKey(challenge);
+
+  const values = await buildExtendedSongsFromPath(songPaths);
+
+  await storeLibraryCache(values);
 
   return values;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,9 +1,12 @@
 import storage from 'electron-json-storage';
+import { ExtendedSong } from './types';
 
 const configName = 'config';
 
 interface ConfigStorage {
   path: string;
+  cache: string;
+  library: ExtendedSong[];
 }
 
 type Keys = keyof ConfigStorage
@@ -17,7 +20,7 @@ export function get<T>(key: Keys) {
   })
 }
 
-export async function set<T>(key: Keys, value: any) {
+export async function set<T>(key: Keys, value: ConfigStorage[typeof key]) {
   return new Promise<T>(async (resolve, reject) => {
 
     storage.get(configName, (getError, config) => {
@@ -25,7 +28,7 @@ export async function set<T>(key: Keys, value: any) {
         return reject(getError)
       }
 
-      const updatedConfig: ConfigStorage = { ...config, [key]: value };
+      const updatedConfig: ConfigStorage = { ...(config as ConfigStorage), [key]: value };
 
       storage.set(
         configName,

--- a/src/useConfig.tsx
+++ b/src/useConfig.tsx
@@ -310,14 +310,17 @@ export function ConfigProvider({ children }) {
       dispatch(setPath(path));
       dispatch(setLoading(true));
 
-      /** Sets path in localStorage (sorta) */
       set('path', path)
 
       try {
+        console.time(`parseLibraryFromPath`)
         const library = await parseLibraryFromPath(path);
+        console.timeEnd(`parseLibraryFromPath`)
+
         console.time(`normalizeLibrary`)
-        dispatch(setLibrary(library));
+        const normalizedLibrary = setLibrary(library);
         console.timeEnd(`normalizeLibrary`)
+        dispatch(normalizedLibrary);
         dispatch(setLoading(false));
       } catch (error) { }
     },


### PR DESCRIPTION
- Creates and stores a string version of the of the songs path array in localStorage.
- Stores stringified library in localStorage after MP3s are parsed.
- On load compares string version of the current songs path array to stored version. If they're the same we can assume the files have not changed and we load and parse the cached library.