### PR TITLE
Ignore "the " when sorting by artist name.

### DIFF
--- a/src/parseLibraryFromPath.ts
+++ b/src/parseLibraryFromPath.ts
@@ -3,6 +3,10 @@ import { parseFile } from "music-metadata";
 import { ExtendedSong } from "./types";
 import { get, set } from "./storage";
 
+function createSortableArtist(artist: string): string {
+  return artist.replace(/^the /i, "");
+}
+
 function stringifySongPaths(paths: string[]): string {
   console.time(`stringifySongPaths`);
   const result = paths.join(" ");
@@ -55,7 +59,8 @@ async function buildExtendedSongsFromPath(
         artist,
         title,
         year,
-        path
+        path,
+        sortableArtist: createSortableArtist(artist),
       });
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,12 @@ export type Song = {
 };
 
 export interface ExtendedSong extends Song {
-  // album: string;
   artist: string;
   title: string;
   year: number;
   path: string;
   duration: number;
+  sortableArtist: string;
 }
 
 export type SongWithKey = ExtendedSong & { key: string };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -45,7 +45,7 @@ export const fillOddRows = ([artist, songs]) => {
  * Currently there is no intent, or reasonable alternative, to sorting by artist so it's safe
  * to hardcode this.
  */
-export const sortByArtist = sortBy(pipe(prop('artist'), toLower));
+export const sortByArtist = sortBy(pipe(prop('sortableArtist'), toLower));
 
 /**
  * In a jukebox if an artist has a odd number of tracks they will display a blank bottom tile before


### PR DESCRIPTION
- Adds a new `sortableArtist` key to ExtendedSong which is the artist name, excluding any leading `the `.
- Updates `sortByArtist` to use new `sortableArtist` key.